### PR TITLE
Fixed: schema no longer cached for tester.

### DIFF
--- a/test.php
+++ b/test.php
@@ -30,7 +30,9 @@ $soap = new SoapClient(
 	array(
 		'authentication' => SOAP_AUTHENTICATION_BASIC,
 		'login' => $cfg->username,
-		'password' => $cfg->password
+		'password' => $cfg->password,
+		'cache_wsdl' => WSDL_CACHE_NONE,
+		'trace' => true,
 	)
 );
 


### PR DESCRIPTION
This will eliminate the client-side caching issue w/ link-tester
